### PR TITLE
Add deleting chunks, add minimum support for new chunk version, add some new methods to WorldData and more

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
 
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.20</version>
+            <version>1.21</version>
         </dependency>
 
         <!-- LevelDB -->
@@ -49,14 +49,14 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.8</version>
         </dependency>
 
         <!-- JUnit 5 -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.0</version>
+            <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/nl/itslars/kosmos/World.java
+++ b/src/main/java/nl/itslars/kosmos/World.java
@@ -116,7 +116,6 @@ public class World {
                     return;
                 } catch (NumberFormatException e) {
                     System.out.println("WARNING: Possibly critical failure. LevelDB failed to parse an entry!");
-                    entry = iterator.next();
                 }
             }
         }

--- a/src/main/java/nl/itslars/kosmos/enums/Difficulty.java
+++ b/src/main/java/nl/itslars/kosmos/enums/Difficulty.java
@@ -1,0 +1,36 @@
+package nl.itslars.kosmos.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Enum for representing each Minecraft difficulty.
+ */
+@AllArgsConstructor
+@Getter
+public enum Difficulty {
+
+    PEACEFUL(0),
+    EASY(1),
+    NORMAL(2),
+    HARD(3),
+    ;
+
+    // The difficulty id.
+    private final int id;
+
+    // The list of all dimensions
+    private static final Difficulty[] DIFFICULTIES = Difficulty.values();
+
+    /**
+     * Retrieves the Difficulty enum based on its id
+     * @param id The difficulty ID
+     * @return The associated enum value
+     */
+    public static Difficulty fromId(int id) {
+        for (Difficulty difficulty : DIFFICULTIES) {
+            if (difficulty.getId() == id) return difficulty;
+        }
+        return null;
+    }
+}

--- a/src/main/java/nl/itslars/kosmos/objects/entity/CustomEntity.java
+++ b/src/main/java/nl/itslars/kosmos/objects/entity/CustomEntity.java
@@ -1,0 +1,123 @@
+package nl.itslars.kosmos.objects.entity;
+
+import nl.itslars.mcpenbt.enums.TagType;
+import nl.itslars.mcpenbt.tags.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static nl.itslars.kosmos.util.EntityNBTConstants.ENTITY_NBT_IDENTIFIER;
+
+/**
+ * A simple class for adding new custom entities to the world.
+ */
+public class CustomEntity extends Entity {
+
+
+    public CustomEntity(CompoundTag parentCompoundTag) {
+        super(parentCompoundTag);
+    }
+
+    /**
+     *
+     * @param identifier entity identifier
+     * @param x x
+     * @param y y
+     * @param z z
+     * @param componentGroups added component groups
+     */
+    public CustomEntity(String identifier, float x, float y, float z, String... componentGroups) {
+        super(getEmpty());
+        setIdentifier(identifier);
+        ArrayList<String> defs = new ArrayList<>();
+        defs.add("+" + identifier);
+        defs.addAll(Arrays.stream(componentGroups).map(s -> "+" + s).collect(Collectors.toList()));
+        setDefinitions(defs);
+        setPosition(x, y, z);
+        setRotation(0, 0);
+    }
+
+    protected void setIdentifier(String identifier) {
+        setStringTag(ENTITY_NBT_IDENTIFIER, identifier);
+    }
+
+    private static CompoundTag getEmpty() {
+        return new CompoundTag("", new ArrayList<>(Arrays.asList(
+                new ByteTag("canPickupItems", (byte) 0),
+                new ByteTag("Chested", (byte) 0),
+                new ByteTag("Color", (byte) 0),
+                new ByteTag("Color2", (byte) 0),
+                new ByteTag("CustomNameVisible", (byte) 0),
+                new ByteTag("Dead", (byte) 0),
+                new ByteTag("hasBoundOrigin", (byte) 0),
+                new ByteTag("hasSetCanPickupItems", (byte) 0),
+                new ByteTag("Invulnerable", (byte) 0),
+                new ByteTag("IsAngry", (byte) 0),
+                new ByteTag("IsAutonomous", (byte) 0),
+                new ByteTag("IsBaby", (byte) 0),
+                new ByteTag("IsEating", (byte) 0),
+                new ByteTag("IsGliding", (byte) 0),
+                new ByteTag("IsGlobal", (byte) 0),
+                new ByteTag("IsIllagerCaptain", (byte) 0),
+                new ByteTag("IsOrphaned", (byte) 0),
+                new ByteTag("IsOutOfControl", (byte) 0),
+                new ByteTag("IsPregnant", (byte) 0),
+                new ByteTag("IsRoaring", (byte) 0),
+                new ByteTag("IsScared", (byte) 0),
+                new ByteTag("IsStunned", (byte) 0),
+                new ByteTag("IsSwimming", (byte) 0),
+                new ByteTag("IsTamed", (byte) 0),
+                new ByteTag("IsTrusting", (byte) 0),
+                new ByteTag("LootDropped", (byte) 0),
+                new ByteTag("NaturalSpawn", (byte) 0),
+                new ByteTag("OnGround", (byte) 0),
+                new ByteTag("Persistent", (byte) 1),
+                new ByteTag("Saddled", (byte) 0),
+                new ByteTag("Sheared", (byte) 0),
+                new ByteTag("ShowBottom", (byte) 0),
+                new ByteTag("Sitting", (byte) 0),
+                new ByteTag("Surface", (byte) 0),
+
+                new FloatTag("BodyRot", 0),
+                new FloatTag("FallDistance", 0),
+
+                new IntTag("boundX", 0),
+                new IntTag("boundY", 0),
+                new IntTag("boundZ", 0),
+                new IntTag("LastDimensionId", 0),
+                new IntTag("MarkVariant", 0),
+                new IntTag("PortalCooldown", 0),
+                new IntTag("SkinID", 0),
+                new IntTag("Strength", 0),
+                new IntTag("StrengthMax", 0),
+                new IntTag("TradeExperience", 0),
+                new IntTag("TradeTier", 0),
+                new IntTag("Variant", 0),
+
+                new ListTag<>("Armor", TagType.TAG_COMPOUND, new ArrayList<>()),
+                new ListTag<>("Attributes", TagType.TAG_COMPOUND, new ArrayList<>()),
+                new ListTag<>("definitions", TagType.TAG_STRING, new ArrayList<>()),
+                new ListTag<>("Mainhand", TagType.TAG_COMPOUND, new ArrayList<>()),
+                new ListTag<>("Offhand", TagType.TAG_COMPOUND, new ArrayList<>()),
+                new ListTag<>("Pos", TagType.TAG_FLOAT, new ArrayList<>(Arrays.asList(new FloatTag("", 0), new FloatTag("", 0), new FloatTag("", 0)))),
+                new ListTag<>("Rotation", TagType.TAG_FLOAT, new ArrayList<>(Arrays.asList(new FloatTag("", 0), new FloatTag("", 0)))),
+                new ListTag<>("Tags", TagType.TAG_END, new ArrayList<>()),
+
+                new LongTag("LeasherID", -1),
+                new LongTag("OwnerNew", -1),
+                new LongTag("TargetID", -1),
+                new LongTag("UniqueID", new Random().nextLong()),
+
+                new ShortTag("AttackTime", (short) 0),
+                new ShortTag("DeathTime", (short) 0),
+                new ShortTag("Fire", (short) 0),
+                new ShortTag("HurtTime", (short) 0),
+
+                new StringTag("CustomName", ""),
+                new StringTag("identifier", "")
+        )));
+    }
+
+}

--- a/src/main/java/nl/itslars/kosmos/objects/entity/CustomEntity.java
+++ b/src/main/java/nl/itslars/kosmos/objects/entity/CustomEntity.java
@@ -5,6 +5,7 @@ import nl.itslars.mcpenbt.tags.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
@@ -29,11 +30,23 @@ public class CustomEntity extends Entity {
      * @param componentGroups added component groups
      */
     public CustomEntity(String identifier, float x, float y, float z, String... componentGroups) {
+        this(identifier, x, y, z, Arrays.asList(componentGroups));
+    }
+
+    /**
+     *
+     * @param identifier entity identifier
+     * @param x x
+     * @param y y
+     * @param z z
+     * @param componentGroups added component groups
+     */
+    public CustomEntity(String identifier, float x, float y, float z, List<String> componentGroups) {
         super(getEmpty());
         setIdentifier(identifier);
         ArrayList<String> defs = new ArrayList<>();
         defs.add("+" + identifier);
-        defs.addAll(Arrays.stream(componentGroups).map(s -> "+" + s).collect(Collectors.toList()));
+        defs.addAll(componentGroups.stream().map(s -> "+" + s).collect(Collectors.toList()));
         setDefinitions(defs);
         setPosition(x, y, z);
         setRotation(0, 0);

--- a/src/main/java/nl/itslars/kosmos/objects/entity/TileEntity.java
+++ b/src/main/java/nl/itslars/kosmos/objects/entity/TileEntity.java
@@ -3,6 +3,10 @@ package nl.itslars.kosmos.objects.entity;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import nl.itslars.mcpenbt.tags.CompoundTag;
+import nl.itslars.mcpenbt.tags.IntTag;
+import nl.itslars.mcpenbt.tags.Tag;
+
+import java.util.Optional;
 
 /**
  * Class used to represent all tile entities. This class should become abstract in the future.
@@ -15,5 +19,62 @@ import nl.itslars.mcpenbt.tags.CompoundTag;
 public class TileEntity {
 
     private final CompoundTag parent;
+
+    /**
+     * Sets the tile entity's x coordinate to the given value
+     * @param value The tile entity's x coordinate
+     */
+    public void setX(int value) {
+        parent.change("x", new IntTag("x", value));
+    }
+
+    /**
+     * Attempts to get the tile entity's x coordinate. Throws an exception if the x setting was not found.
+     * @return The tile entity's x coordinate
+     */
+    public int getX() {
+        Optional<Tag> tagOptional = parent.getByName("x");
+        if (!tagOptional.isPresent()) throw new IllegalArgumentException("x setting was not found in level.dat");
+
+        return tagOptional.get().getAsInt().getValue();
+    }
+
+    /**
+     * Sets the tile entity's y coordinate to the given value
+     * @param value The tile entity's y coordinate
+     */
+    public void setY(int value) {
+        parent.change("y", new IntTag("y", value));
+    }
+
+    /**
+     * Attempts to get the tile entity's y coordinate. Throws an exception if the y setting was not found.
+     * @return The tile entity's y coordinate
+     */
+    public int getY() {
+        Optional<Tag> tagOptional = parent.getByName("y");
+        if (!tagOptional.isPresent()) throw new IllegalArgumentException("y setting was not found in level.dat");
+
+        return tagOptional.get().getAsInt().getValue();
+    }
+
+    /**
+     * Sets the tile entity's z coordinate to the given value
+     * @param value The tile entity's z coordinate
+     */
+    public void setZ(int value) {
+        parent.change("z", new IntTag("z", value));
+    }
+
+    /**
+     * Attempts to get the tile entity's z coordinate. Throws an exception if the z setting was not found.
+     * @return The tile entity's z coordinate
+     */
+    public int getZ() {
+        Optional<Tag> tagOptional = parent.getByName("z");
+        if (!tagOptional.isPresent()) throw new IllegalArgumentException("z setting was not found in level.dat");
+
+        return tagOptional.get().getAsInt().getValue();
+    }
 
 }

--- a/src/main/java/nl/itslars/kosmos/objects/settings/LevelDatFile.java
+++ b/src/main/java/nl/itslars/kosmos/objects/settings/LevelDatFile.java
@@ -3,6 +3,7 @@ package nl.itslars.kosmos.objects.settings;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import lombok.Getter;
+import nl.itslars.kosmos.enums.Difficulty;
 import nl.itslars.kosmos.enums.GameMode;
 import nl.itslars.kosmos.enums.GameRule;
 import nl.itslars.kosmos.enums.Generator;
@@ -225,6 +226,25 @@ public class LevelDatFile {
         if (!tagOptional.isPresent()) throw new IllegalArgumentException("FlatWorldLayers setting was not found in level.dat");
 
         return GSON.fromJson(tagOptional.get().getAsString().getValue(), FlatWorldLayers.class);
+    }
+
+    /**
+     * Sets the world's difficulty to the given value
+     * @param value The difficulty
+     */
+    public void setDifficulty(Difficulty value) {
+        parentCompoundTag.change("Difficulty", new IntTag("Difficulty", value.getId()));
+    }
+
+    /**
+     * Attempts to get the difficulty of the world. Throws an exception if the game mode setting was not found.
+     * @return The difficulty
+     */
+    public Difficulty getDifficulty() {
+        Optional<Tag> tagOptional = parentCompoundTag.getByName("Difficulty");
+        if (!tagOptional.isPresent()) throw new IllegalArgumentException("Difficulty setting was not found in level.dat");
+
+        return Difficulty.fromId(tagOptional.get().getAsInt().getValue());
     }
 
 }

--- a/src/main/java/nl/itslars/kosmos/objects/settings/LevelDatFile.java
+++ b/src/main/java/nl/itslars/kosmos/objects/settings/LevelDatFile.java
@@ -96,6 +96,15 @@ public class LevelDatFile {
     }
 
     /**
+     * Returns whether the gamerule provided is set in dat file.
+     * @param gameRule The gamerule
+     * @return Boolean whether the gamerule is set
+     */
+    public boolean hasGameRule(GameRule gameRule) {
+        return parentCompoundTag.getByName(gameRule.getLevelDatName()).isPresent();
+    }
+
+    /**
      * Sets the game's cheat state to the given boolean value
      * @param value The cheat state (true if enabled, false if disabled)
      */

--- a/src/main/java/nl/itslars/kosmos/objects/world/Block.java
+++ b/src/main/java/nl/itslars/kosmos/objects/world/Block.java
@@ -3,6 +3,7 @@ package nl.itslars.kosmos.objects.world;
 import lombok.Getter;
 import lombok.Setter;
 import nl.itslars.kosmos.enums.BlockType;
+import nl.itslars.kosmos.objects.entity.TileEntity;
 import nl.itslars.mcpenbt.tags.CompoundTag;
 import nl.itslars.mcpenbt.tags.IntTag;
 import nl.itslars.mcpenbt.tags.StringTag;
@@ -36,6 +37,9 @@ public class Block {
     private final int x;
     private final int y;
     private final int z;
+    // Tile entity associated with this block
+    @Setter
+    private TileEntity tileEntity;
 
     public Block(CompoundTag states, String name, int version, int x, int y, int z) {
         this.states = states;

--- a/src/main/java/nl/itslars/kosmos/objects/world/Block.java
+++ b/src/main/java/nl/itslars/kosmos/objects/world/Block.java
@@ -79,12 +79,18 @@ public class Block {
         Optional<Tag> statesTag = compoundTag.getByName("states");
         Optional<Tag> nameTag = compoundTag.getByName("name");
         Optional<Tag> versionTag = compoundTag.getByName("version");
-        if (!statesTag.isPresent() || !nameTag.isPresent() || !versionTag.isPresent()) {
+        if (statesTag.isPresent() & nameTag.isPresent() && versionTag.isPresent()) {
+            CompoundTag states = statesTag.get().getAsCompound();
+            String name = nameTag.get().getAsString().getValue();
+            int version = versionTag.get().getAsInt().getValue();
+            return new Block(states, name, version, x, y, z);
+        }
+        // Older worlds and worlds converted from Java might not have those tags present
+        else if (nameTag.isPresent()) {
+            String name = nameTag.get().getAsString().getValue();
+            return new Block(name, x, y, z);
+        } else {
             throw new IllegalStateException("Failed to deserialize the block, a parsing error occured.");
         }
-        CompoundTag states = statesTag.get().getAsCompound();
-        String name = nameTag.get().getAsString().getValue();
-        int version = versionTag.get().getAsInt().getValue();
-        return new Block(states, name, version, x, y, z);
     }
 }

--- a/src/main/java/nl/itslars/kosmos/objects/world/Block.java
+++ b/src/main/java/nl/itslars/kosmos/objects/world/Block.java
@@ -79,7 +79,7 @@ public class Block {
         Optional<Tag> statesTag = compoundTag.getByName("states");
         Optional<Tag> nameTag = compoundTag.getByName("name");
         Optional<Tag> versionTag = compoundTag.getByName("version");
-        if (statesTag.isPresent() & nameTag.isPresent() && versionTag.isPresent()) {
+        if (statesTag.isPresent() && nameTag.isPresent() && versionTag.isPresent()) {
             CompoundTag states = statesTag.get().getAsCompound();
             String name = nameTag.get().getAsString().getValue();
             int version = versionTag.get().getAsInt().getValue();

--- a/src/main/java/nl/itslars/kosmos/objects/world/Chunk.java
+++ b/src/main/java/nl/itslars/kosmos/objects/world/Chunk.java
@@ -198,4 +198,12 @@ public class Chunk {
             world.getCachedChunks().get(dimension).remove(chunkX);
         }
     }
+
+    /**
+     * Deletes the current chunk from the world
+     */
+    public void delete() {
+        world.deleteChunk(getDimension(), getChunkX(), getChunkZ());
+    }
+
 }

--- a/src/main/java/nl/itslars/kosmos/objects/world/Chunk.java
+++ b/src/main/java/nl/itslars/kosmos/objects/world/Chunk.java
@@ -47,8 +47,9 @@ public class Chunk {
     /**
      * Retrieves the block that is at the given in-chunk coordinates. If the block didn't exist (because there was
      * no {@link SubChunk} there), an empty {@link Optional} is returned.
+     *
      * @param translatedX The translated X coordinate (the 'local' x coordinate, ranging from 0-15) of the block
-     * @param y The y coordinate of the block
+     * @param y           The y coordinate of the block
      * @param translatedZ The translated Z coordinate (the 'local' z coordinate, ranging from 0-15) of the block
      * @return An {@link Optional} containing the block if present, empty otherwise.
      */
@@ -66,10 +67,11 @@ public class Chunk {
     /**
      * Sets a block at the given in-chunk coordinates. If the block was successfully created, the block is returned.
      * If the block could not be created, an empty {@link Optional} is returned.
+     *
      * @param translatedX The translated X coordinate (the 'local' x coordinate, ranging from 0-15) of the block
-     * @param y The y coordinate of the block
+     * @param y           The y coordinate of the block
      * @param translatedZ The translated Z coordinate (the 'local' z coordinate, ranging from 0-15) of the block
-     * @param blockType The block type to place
+     * @param blockType   The block type to place
      * @return An {@link Optional} containing the resulting block if present, empty otherwise.
      */
     public Optional<Block> setBlock(int translatedX, int y, int translatedZ, BlockType blockType) {
@@ -79,10 +81,11 @@ public class Chunk {
     /**
      * Sets a block at the given in-chunk coordinates. If the block was successfully created, the block is returned.
      * If the block could not be created, an empty {@link Optional} is returned.
+     *
      * @param translatedX The translated X coordinate (the 'local' x coordinate, ranging from 0-15) of the block
-     * @param y The y coordinate of the block
+     * @param y           The y coordinate of the block
      * @param translatedZ The translated Z coordinate (the 'local' z coordinate, ranging from 0-15) of the block
-     * @param name The name of the block type to place
+     * @param name        The name of the block type to place
      * @return An {@link Optional} containing the resulting block if present, empty otherwise.
      */
     public Optional<Block> setBlock(int translatedX, int y, int translatedZ, String name) {
@@ -104,6 +107,7 @@ public class Chunk {
     /**
      * Make sure all chunks up to and including the desired chunk height are created.
      * The desired chunk height may be at most 15, because the world height limit is at 256 blocks.
+     *
      * @param desiredChunkHeight The desired chunk height
      */
     public void ensureChunkSpace(int desiredChunkHeight) {
@@ -117,6 +121,7 @@ public class Chunk {
 
     /**
      * Creates and initializes a new {@link SubChunk} for the current chunk
+     *
      * @param chunkY The height of the {@link SubChunk}
      * @return The newly create {@link SubChunk}
      */
@@ -154,6 +159,7 @@ public class Chunk {
 
     /**
      * Retrieves the X coordinate of this chunk
+     *
      * @return The X coordinate
      */
     public int getX() {
@@ -163,6 +169,7 @@ public class Chunk {
 
     /**
      * Retrieves the Z coordinate of this chunk
+     *
      * @return The Z coordinate
      */
     public int getZ() {
@@ -185,17 +192,23 @@ public class Chunk {
 
     /**
      * Unloads the current chunk from the cached chunk map in the {@link WorldData} chunk storage
+     *
      * @param save Whether the chunk should be saved before it is unloaded
      */
     public void unload(boolean save) {
-        if (save) save();
+        if (save) {
+            save();
+        }
 
         // Retrieve the (sub)map containing this chunk, and remove this chunk from that map
         Map<Integer, Chunk> zs = world.getCachedChunks().get(dimension).get(chunkX);
-        zs.remove(chunkZ);
-        // If the new map is empty, remove it entirely from the chunk map
-        if (zs.size() == 0) {
-            world.getCachedChunks().get(dimension).remove(chunkX);
+        // If chunk is deleted, zs might be null
+        if (zs != null) {
+            zs.remove(chunkZ);
+            // If the new map is empty, remove it entirely from the chunk map
+            if (zs.size() == 0) {
+                world.getCachedChunks().get(dimension).remove(chunkX);
+            }
         }
     }
 

--- a/src/main/java/nl/itslars/kosmos/objects/world/WorldData.java
+++ b/src/main/java/nl/itslars/kosmos/objects/world/WorldData.java
@@ -103,6 +103,58 @@ public class WorldData implements Closeable {
         world.close();
     }
 
+    /**
+     * Returns whether the OVERWORLD chunk is generated in the world
+     *
+     * @param dimension The chunk dimension
+     * @param chunkX    The chunk X
+     * @param chunkZ    The chunk Z
+     * @return is the chunk generated
+     */
+    public boolean isGenerated(Dimension dimension, int chunkX, int chunkZ) {
+        Map<Integer, ChunkPreset> zChunkPresets = chunkPresets.get(dimension).get(chunkX);
+        if (zChunkPresets == null) return false;
+        ChunkPreset chunkPreset = zChunkPresets.get(chunkZ);
+        return chunkPreset != null;
+    }
+
+    /**
+     * Returns whether the OVERWORLD chunk is generated in the world
+     *
+     * @param chunkX    The chunk X
+     * @param chunkZ    The chunk Z
+     * @return is the chunk generated
+     */
+    public boolean isGenerated(int chunkX, int chunkZ) {
+        return isGenerated(Dimension.OVERWORLD, chunkX, chunkZ);
+    }
+
+    /**
+     * Returns whether the OVERWORLD chunk is loaded and cached by the library
+     *
+     * @param dimension The chunk dimension
+     * @param chunkX    The chunk X
+     * @param chunkZ    The chunk Z
+     * @return is the chunk cached
+     */
+    public boolean isCached(Dimension dimension, int chunkX, int chunkZ) {
+        Map<Integer, Chunk> zChunks = cachedChunks.get(dimension).get(chunkX);
+        if (zChunks == null) return false;
+        Chunk chunk = zChunks.get(chunkZ);
+        return chunk != null;
+    }
+
+    /**
+     * Returns whether the OVERWORLD chunk is loaded and cached by the library
+     *
+     * @param chunkX    The chunk X
+     * @param chunkZ    The chunk Z
+     * @return is the chunk cached
+     */
+    public boolean isCached(int chunkX, int chunkZ) {
+        return isCached(Dimension.OVERWORLD, chunkX, chunkZ);
+    }
+
     // ==============================================================
     //                 WORLD MODIFICATION METHODS
     // ==============================================================

--- a/src/main/java/nl/itslars/kosmos/objects/world/WorldData.java
+++ b/src/main/java/nl/itslars/kosmos/objects/world/WorldData.java
@@ -616,4 +616,42 @@ public class WorldData implements Closeable {
         players.clear();
         playerPointers.clear();
     }
+
+    /**
+     * Deletes the OVERWORLD chunk at the given chunk X and Z
+     *
+     * @param chunkX The chunk X
+     * @param chunkZ The chunk Z
+     */
+    public void deleteChunk(int chunkX, int chunkZ) {
+        deleteChunk(Dimension.OVERWORLD, chunkX, chunkZ);
+    }
+
+    /**
+     * Deletes the chunk at the given dimension and chunk X and Z
+     *
+     * @param dimension The chunk dimension
+     * @param chunkX    The chunk X
+     * @param chunkZ    The chunk Z
+     */
+    public void deleteChunk(Dimension dimension, int chunkX, int chunkZ) {
+        // If chunk is not generated, we don't have to remove it
+        if (!isGenerated(dimension, chunkZ, chunkX)) return;
+        // Remove chunk preset
+        ChunkPreset chunkPreset = chunkPresets.get(dimension).get(chunkX).remove(chunkZ);
+        // If the new map is empty, remove it entirely from the preset map
+        if (chunkPresets.get(dimension).get(chunkX).isEmpty()) {
+            chunkPresets.get(dimension).remove(chunkX);
+        }
+        // Add all chunk related keys to deletionKeys
+        deletionKeys.addAll(Chunks.getDeletionKeys(chunkPreset));
+        // If chunk was already cached, we also need to remove the cache
+        if (isCached(dimension, chunkZ, chunkX)) {
+            cachedChunks.get(dimension).get(chunkX).remove(chunkZ);
+            // If the new map is empty, remove it entirely from the chunk map
+            if (cachedChunks.get(dimension).get(chunkX).isEmpty()) {
+                cachedChunks.get(dimension).remove(chunkX);
+            }
+        }
+    }
 }

--- a/src/main/java/nl/itslars/kosmos/objects/world/WorldData.java
+++ b/src/main/java/nl/itslars/kosmos/objects/world/WorldData.java
@@ -723,6 +723,24 @@ public class WorldData implements Closeable {
     }
 
     /**
+     * Deletes given chunk
+     *
+     * @param chunk The chunk
+     */
+    public void deleteChunk(Chunk chunk) {
+        deleteChunk(chunk.getDimension(), chunk.getChunkX(), chunk.getChunkZ());
+    }
+
+    /**
+     * Deletes given chunk
+     *
+     * @param chunk The chunk preset
+     */
+    public void deleteChunk(ChunkPreset chunk) {
+        deleteChunk(chunk.getDimension(), chunk.getX(), chunk.getZ());
+    }
+
+    /**
      * Deletes the OVERWORLD chunk at the given chunk X and Z
      *
      * @param chunkX The chunk X

--- a/src/main/java/nl/itslars/kosmos/util/Chunks.java
+++ b/src/main/java/nl/itslars/kosmos/util/Chunks.java
@@ -31,6 +31,26 @@ public class Chunks {
     }
 
     /**
+     * Returns a list of keys to delete from LevelDB to delete a chunk
+     * @param preset The chunk preset to delete
+     * @return list of keys to delete
+     */
+    public static List<byte[]> getDeletionKeys(ChunkPreset preset) {
+        ArrayList<byte[]> result = new ArrayList<>(19);
+        // 2D Data
+        result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) 45, (byte) 0));
+        // Entities
+        result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) 49, (byte) 0));
+        // Tile Entities
+        result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) 50, (byte) 0));
+        // SubChunks
+        for (byte subChunkHeight = 0; subChunkHeight < 16; subChunkHeight++) {
+            result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) 47, subChunkHeight));
+        }
+        return result;
+    }
+
+    /**
      * Loads a chunk from the given preset from the LevelDB storage
      * @param db The LevelDB storage
      * @param preset The chunk preset

--- a/src/main/java/nl/itslars/kosmos/util/Chunks.java
+++ b/src/main/java/nl/itslars/kosmos/util/Chunks.java
@@ -164,8 +164,11 @@ public class Chunks {
                 int version = inputStream.read();
                 // Read the amount of storage sections in this subchunk (1 default, 2 for water logging)
                 int storageCount = 1;
-                if (version == 8) {
+                if (version >= 8) {
                     storageCount = inputStream.read();
+                }
+                if (version >= 9) {
+                    inputStream.read();
                 }
                 SubChunk resultingSubChunk = null;
                 // Loop through all storage sections

--- a/src/main/java/nl/itslars/kosmos/util/Chunks.java
+++ b/src/main/java/nl/itslars/kosmos/util/Chunks.java
@@ -44,6 +44,7 @@ public class Chunks {
         loadChunkEntities(db, chunk);
         loadChunkTileEntities(db, chunk);
         loadChunkSubChunks(db, chunk);
+        linkTileEntities(chunk);
         return chunk;
     }
 
@@ -232,6 +233,22 @@ public class Chunks {
             } catch (IOException e) {
                 e.printStackTrace();
             }
+        }
+    }
+
+    /**
+     * Links TileEntities to Blocks
+     * @param chunk The chunk object
+     */
+    private static void linkTileEntities(Chunk chunk) {
+        for (TileEntity tileEntity : chunk.getTileEntities()) {
+            int localX = tileEntity.getX() % 16;
+            int localZ = tileEntity.getZ() % 16;
+            if (localX < 0) localX += 16;
+            if (localZ < 0) localZ += 16;
+            chunk.getBlock(localX, tileEntity.getY(), localZ).ifPresent(block -> {
+                block.setTileEntity(tileEntity);
+            });
         }
     }
 

--- a/src/main/java/nl/itslars/kosmos/util/Chunks.java
+++ b/src/main/java/nl/itslars/kosmos/util/Chunks.java
@@ -36,17 +36,19 @@ public class Chunks {
      * @return list of keys to delete
      */
     public static List<byte[]> getDeletionKeys(ChunkPreset preset) {
-        ArrayList<byte[]> result = new ArrayList<>(19);
-        // 2D Data
-        result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) 45, (byte) 0));
-        // Entities
-        result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) 49, (byte) 0));
-        // Tile Entities
-        result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) 50, (byte) 0));
-        // SubChunks
-        for (byte subChunkHeight = 0; subChunkHeight < 16; subChunkHeight++) {
-            result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) 47, subChunkHeight));
+        ArrayList<byte[]> result = new ArrayList<>();
+        // Remove ALL keys related to the chunk (along with legacy ones)
+        for (int i = 44; i <= 59; i++) {
+            if (i != 47) {
+                result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) i, (byte) 0));
+            } else {
+                // SubChunks
+                for (byte subChunkHeight = 0; subChunkHeight < 16; subChunkHeight++) {
+                    result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) 47, subChunkHeight));
+                }
+            }
         }
+        result.add(generateLevelDBKey(preset.getX(), preset.getZ(), preset.getDimension(), (byte) 118, (byte) 0));
         return result;
     }
 

--- a/src/main/java/nl/itslars/kosmos/util/Chunks.java
+++ b/src/main/java/nl/itslars/kosmos/util/Chunks.java
@@ -77,6 +77,8 @@ public class Chunks {
         // Generate the level DB key
         byte[] levelDBKey = generateLevelDBKey(preset.getChunkX(), preset.getChunkZ(), preset.getDimension(), (byte) 45, (byte) 0);
         byte[] value = db.get(levelDBKey);
+        // Sometimes when chunk is generated completely empty, it doesn't have data on terrain
+        if (value == null) return;
 
         // Loop through the 2d chunk, and set the chunk's elevation and biomes accordingly
         for (int z = 0; z < 16; z++) {


### PR DESCRIPTION
Changes:
 - Implemented deleting chunks
 - Added isGenerated method, that returns whether a chunk is generated in the world
 - Added isCached method, that returns whether a chunk is loaded and cached by the library
 - Added getChunkCount method, that returns how many chunks there are in the world
 - Added new variants of the forEachChunk method, that accept `BiFunction<Chunk, Exception, Boolean>` instead, so you can still iterate over all chunks and get Exception instead of Chunk and still continue to iterate. Useful for applications, that just check some information about world. It can just report that it failed to load x chunks.
 - Added minimum support for new chunk version 9 (there is an extra byte after storage count, I'm planning to add a better support soon)
 - Added linking TileEntity to Block
 - Add setting difficulty
 - Add hasGameRule method
 - Add CustomEntity class, that has all required properties initialized for quick custom entity creation
 - Update lombok, to enable support for compiling with Java 16
 - Update other dependencies as well
 - Fix an error, when two LevelDB entries next to each other threw NumberFormatException
 - Fix loading older worlds and worlds converted from Java Edition
 - Fix a bug, when loading generated chunks without any terrain (mostly in end dimension)

Unfortunately due to some issues in my repo, 10 commits were duplicated :/